### PR TITLE
Feat/prelude defs

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 	version string = "0.0.1"
 	handler protocol.Handler
 	tempDir string
-	states = make(map[string]*state.State)
+	states  = make(map[string]*state.State)
 )
 
 func main() {

--- a/state/state.go
+++ b/state/state.go
@@ -50,6 +50,30 @@ func NewFromFile(fname string) (*State, error) {
 	return state, nil
 }
 
+func PreludeState() *State {
+	source := ast.Source{
+		Name: "graphqlsp_internal",
+		Input: "",
+	}
+	schema, err := gqlparser.LoadSchema(&source)
+	if err != nil {
+		panic(err)
+	}
+
+	state := &State{
+		schema: schema,
+		locator: make(locator),
+	}
+
+	state.walk(schema.Query)
+	state.walk(schema.Mutation)
+	for _, v := range schema.Types {
+		state.walk(v)
+	}
+
+	return state
+}
+
 func (s *State) GetDefinitionOf(line, col int) *Position {
 	sym := s.locator.get(line, col)
 	ty := lift[*ast.Type](sym)

--- a/state/state.go
+++ b/state/state.go
@@ -196,6 +196,10 @@ func (s *State) handleArg(ty *ast.ArgumentDefinition) {
 }
 
 func (s *State) walk(def *ast.Definition) {
+	if def == nil {
+		return
+	}
+
 	switch def.Kind {
 	case ast.Scalar:
 		s.handleDef(def)

--- a/state/state.go
+++ b/state/state.go
@@ -52,7 +52,7 @@ func NewFromFile(fname string) (*State, error) {
 
 func PreludeState() *State {
 	source := ast.Source{
-		Name: "graphqlsp_internal",
+		Name:  "graphqlsp_internal",
 		Input: "",
 	}
 	schema, err := gqlparser.LoadSchema(&source)
@@ -61,7 +61,7 @@ func PreludeState() *State {
 	}
 
 	state := &State{
-		schema: schema,
+		schema:  schema,
 		locator: make(locator),
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -15,3 +15,11 @@ func TestGetDef(t *testing.T) {
 	assert.NotNil(t, pos)
 	assert.Equal(t, &Position{1, 6, 5, false}, pos)
 }
+
+func TestPreludeState(t *testing.T) {
+	s := PreludeState()
+	assert.NotNil(t, s)
+	assert.NotNil(t, s.schema.Types["Int"])
+	assert.Equal(t, 4, s.schema.Types["Int"].Position.Line)
+	assert.Equal(t, 8, s.schema.Types["Int"].Position.Column)
+}


### PR DESCRIPTION
Hacky implementation of not failing when running on the prelude file. gqlparser always adds a source for the builtin types, and this was mucking up the locator